### PR TITLE
Track MCP server uptime in metrics

### DIFF
--- a/packages/mcp-server/src/mcp-server.test.ts
+++ b/packages/mcp-server/src/mcp-server.test.ts
@@ -125,10 +125,19 @@ describe("McpServer (MCP SDK HTTP Transport)", () => {
   });
 
   it("metrics tool returns counts", async () => {
-    const m = await callTool(testKey, "metrics", {});
-    const mData = extractJsonContent(m.body.result);
-    expect(typeof mData.notes).toBe("number");
-    expect(typeof mData.uptimeMs).toBe("number");
+    const first = await callTool(testKey, "metrics", {});
+    const firstData = extractJsonContent(first.body.result);
+    expect(typeof firstData.notes).toBe("number");
+    expect(typeof firstData.uptimeMs).toBe("number");
+    expect(firstData.uptimeMs).toBeGreaterThanOrEqual(0);
+
+    await new Promise((resolve) => setTimeout(resolve, 10));
+
+    const second = await callTool(testKey, "metrics", {});
+    const secondData = extractJsonContent(second.body.result);
+    expect(typeof secondData.notes).toBe("number");
+    expect(typeof secondData.uptimeMs).toBe("number");
+    expect(secondData.uptimeMs).toBeGreaterThanOrEqual(firstData.uptimeMs);
   });
 
   it("re-initialization returns either error or same protocolVersion", async () => {

--- a/packages/mcp-server/src/mcp-server.ts
+++ b/packages/mcp-server/src/mcp-server.ts
@@ -27,6 +27,7 @@ export class McpServer {
   private noteService: NoteService | null;
   private apiKey: string | null;
   private running = false;
+  private startedAt: number | null = null;
   private readonly sdk: SdkMcpServer;
   private readonly transport: StreamableHTTPServerTransport;
   setApiKey(key: string) { this.apiKey = key; }
@@ -201,7 +202,8 @@ export class McpServer {
       async () => {
         const svc = this.requireService();
         const notes = await svc.list({} as any);
-        return { content: [{ type: "text", text: JSON.stringify({ notes: notes.length, uptimeMs: Date.now(), serverRunning: this.running }) }] };
+        const uptimeMs = this.startedAt ? Date.now() - this.startedAt : 0;
+        return { content: [{ type: "text", text: JSON.stringify({ notes: notes.length, uptimeMs, serverRunning: this.running }) }] };
       },
     );
   }
@@ -309,6 +311,7 @@ export class McpServer {
     });
 
     this.httpServer.listen(this.port, "0.0.0.0", () => {
+      this.startedAt = Date.now();
       log.start(`MCP server (SDK) listening http://localhost:${this.port}`);
       log.info(`Health: http://localhost:${this.port}/health`);
       log.info(`MCP: http://localhost:${this.port}/mcp`);
@@ -321,6 +324,7 @@ export class McpServer {
     await this.sdk.close();
     await new Promise<void>((resolve) => this.httpServer?.close(() => resolve()));
     this.httpServer = null;
+    this.startedAt = null;
     log.stop("MCP server stopped");
   }
 }


### PR DESCRIPTION
## Summary
- track when the MCP HTTP server starts listening so uptime metrics are based on server availability
- report uptime as the elapsed time since the server started in the `metrics` tool response
- verify the metrics tool reports non-negative and increasing uptime in its test

## Testing
- bun test packages/mcp-server/src/mcp-server.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68ec25adc2188320a5f49b43296fb461