### PR TITLE
Use secure randomness for MCP API key rotation

### DIFF
--- a/packages/mcp-server/src/mcp-config-routes.test.ts
+++ b/packages/mcp-server/src/mcp-config-routes.test.ts
@@ -38,6 +38,10 @@ describe("McpServer config routes", () => {
   it("rotates api key via rotate flag and rejects old key", async () => {
     const rotate = await post("http://localhost:27126/config/key", { rotate: true }, key);
     expect(rotate.status).toBe(200);
+    const rotatedKey = (server as any).apiKey as string | null;
+    expect(typeof rotatedKey).toBe("string");
+    expect(rotatedKey).toMatch(/^[0-9a-f]{64}$/);
+
     // Old key should now fail auth for protected endpoint (/mcp)
     const unauthorized = await fetch("http://localhost:27126/mcp", { method: "POST", headers: { "Content-Type": "application/json", Authorization: `Bearer ${key}` }, body: JSON.stringify({ jsonrpc: "2.0", id: 0, method: "tools/list", params: {} }) });
     // Either 401 or 400 (if it got past auth but missing session). We want 401 to confirm key change.

--- a/packages/mcp-server/src/mcp-server.ts
+++ b/packages/mcp-server/src/mcp-server.ts
@@ -1,3 +1,4 @@
+import { randomBytes } from "node:crypto";
 import { createServer, type Server } from "node:http";
 import type { NoteService } from "@orchard/core";
 import { z } from "zod";
@@ -254,7 +255,7 @@ export class McpServer {
             const schema = z.object({ rotate: z.boolean().optional(), newKey: z.string().optional() });
             const cfg = schema.parse(parsed);
             if (cfg.rotate || cfg.newKey) {
-              this.apiKey = cfg.newKey || Math.random().toString(16).slice(2) + Math.random().toString(16).slice(2);
+              this.apiKey = cfg.newKey || randomBytes(32).toString("hex");
             }
             res.statusCode = 200;
             res.setHeader("Content-Type", "application/json");


### PR DESCRIPTION
## Summary
- generate rotated MCP API keys with crypto-secure random bytes
- verify rotated keys are 64-character hex strings in the config route tests

## Testing
- bun test packages/mcp-server/src/mcp-config-routes.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68ec25b0f9108320b6b9dd58d991bb77