### PR TITLE
Use randomUUID for MCP session IDs

### DIFF
--- a/packages/mcp-server/src/mcp-server.ts
+++ b/packages/mcp-server/src/mcp-server.ts
@@ -1,4 +1,5 @@
 import { createServer, type Server } from "node:http";
+import { randomUUID } from "node:crypto";
 import type { NoteService } from "@orchard/core";
 import { z } from "zod";
 import { McpServer as SdkMcpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
@@ -46,7 +47,10 @@ export class McpServer {
     this.registerTools();
 
     // Streamable transport; JSON responses enabled for simple tool calls over POST
-    this.transport = new StreamableHTTPServerTransport({ enableJsonResponse: true, sessionIdGenerator: () => Math.random().toString(36).slice(2) });
+    this.transport = new StreamableHTTPServerTransport({
+      enableJsonResponse: true,
+      sessionIdGenerator: () => randomUUID(),
+    });
   }
 
   setNoteService(svc: NoteService) { this.noteService = svc; }


### PR DESCRIPTION
## Summary
- switch the MCP HTTP transport session ID generator to use Node's crypto randomUUID

## Testing
- bun test packages/mcp-server/src/mcp-server.test.ts
- bun test packages/mcp-server/src/mcp-config-routes.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68ec25b4337c8320a4f86746380f17a9