### PR TITLE
feat(mcp-server): add list tags tool

### DIFF
--- a/packages/mcp-server/README.md
+++ b/packages/mcp-server/README.md
@@ -10,6 +10,7 @@ Minimal HTTP JSON-RPC endpoint exposing Orchard note CRUD via MCP Streamable HTT
   - `tools/call` → invoke a tool by name with arguments
 - Tools implemented:
   - `list_notes` (filters: `tag`, `search`)
+  - `list_tags` (unique tags with usage counts)
   - `get_note` (id)
   - `create_note` (id, title?, body?, tags?, frontmatter?)
   - `update_note` (id, version, optional fields)

--- a/packages/mcp-server/src/mcp-server.test.ts
+++ b/packages/mcp-server/src/mcp-server.test.ts
@@ -21,6 +21,8 @@ describe("McpServer (MCP SDK HTTP Transport)", () => {
 
   beforeAll(async () => {
     svc = new NoteService({ adapter: createMemoryAdapter() });
+    await svc.create({ id: "SeedOne", title: "Seed One", body: "Seed content", tags: ["seedA", "shared"] });
+    await svc.create({ id: "SeedTwo", title: "Seed Two", body: "More seed content", tags: ["seedB"] });
     testKey = "testkey1234567890";
     server = new McpServer({ noteService: svc, apiKey: testKey });
     await server.start();
@@ -61,6 +63,7 @@ describe("McpServer (MCP SDK HTTP Transport)", () => {
     expect(init.body.result?.protocolVersion || init.body.result?.serverInfo).toBeTruthy();
     const { body } = await listTools(testKey);
     expect(body.result?.tools?.some((t: any) => t.name === "create_note")).toBe(true);
+    expect(body.result?.tools?.some((t: any) => t.name === "list_tags")).toBe(true);
   });
 
   it("creates notes and lists via list_notes filters", async () => {
@@ -84,6 +87,16 @@ describe("McpServer (MCP SDK HTTP Transport)", () => {
     const searchData = extractJsonContent(search.body.result);
     const ids = searchData.notes.map((n: any) => n.id).sort();
     expect(ids).toEqual(["beta.md", "gamma.md"]);
+
+    const tags = await callTool(testKey, "list_tags", {});
+    const tagData = extractJsonContent(tags.body.result);
+    expect(tagData.tags).toEqual([
+      { name: "seedA", count: 1 },
+      { name: "seedB", count: 1 },
+      { name: "shared", count: 1 },
+      { name: "tagA", count: 2 },
+      { name: "tagB", count: 2 },
+    ]);
   });
 
   it("gets a note", async () => {

--- a/packages/mcp-server/src/mcp-server.ts
+++ b/packages/mcp-server/src/mcp-server.ts
@@ -104,6 +104,32 @@ export class McpServer {
       },
     );
 
+    // list_tags
+    this.sdk.tool(
+      "list_tags",
+      {},
+      async () => {
+        const svc = this.requireService();
+        try {
+          const notes = await svc.list({} as any);
+          const counts = new Map<string, number>();
+          for (const note of notes) {
+            for (const tag of note.tags ?? []) {
+              const current = counts.get(tag) ?? 0;
+              counts.set(tag, current + 1);
+            }
+          }
+          const tags = Array.from(counts.entries())
+            .map(([name, count]) => ({ name, count }))
+            .sort((a, b) => a.name.localeCompare(b.name));
+          return { content: [{ type: "text", text: JSON.stringify({ tags }) }] };
+        } catch (e) {
+          const mapped = mapError(e);
+          return errorContent(mapped.code, mapped.details);
+        }
+      },
+    );
+
     // get_note
     this.sdk.tool(
       "get_note",


### PR DESCRIPTION
## Summary
- add a `list_tags` MCP tool that aggregates unique tag names and counts from existing notes
- seed the MCP server tests with tagged notes and verify the new tool surfaces in `tools/list` and returns the expected payload
- document the additional tool capability in the MCP server README

## Testing
- bun test packages/mcp-server/src/mcp-server.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68ec25b62a9c8320aafdeefda9b0fd34