### PR TITLE
Add metadata to list_notes payload

### DIFF
--- a/packages/mcp-server/README.md
+++ b/packages/mcp-server/README.md
@@ -16,6 +16,32 @@ Minimal HTTP JSON-RPC endpoint exposing Orchard note CRUD via MCP Streamable HTT
   - `delete_note` (id, version)
   - `metrics` (note count + uptime flag)
 
+### `list_notes` payload
+
+Each entry in the response now exposes richer metadata so MCP clients can render vault state without additional calls:
+
+```jsonc
+{
+  "notes": [
+    {
+      "id": "alpha.md",
+      "title": "Alpha",
+      "version": "<sha256>",
+      "updatedAt": 1710000000000,
+      "tags": ["tagA"],
+      "frontmatterSummary": {
+        "summary": "delta note",
+        "rating": 5
+      }
+    }
+  ]
+}
+```
+
+- `updatedAt` is the file modification time in epoch milliseconds.
+- `tags` mirrors the normalized frontmatter tag array (empty if unspecified).
+- `frontmatterSummary` is optional and includes non-title/tag frontmatter keys whose values are simple scalars or short string/number arrays. Use it for lightweight previews while falling back to `get_note` for full bodies/frontmatter.
+
 ### Health Endpoint
 `GET /health` returns readiness fields:
 ```jsonc

--- a/packages/mcp-server/src/mcp-server.test.ts
+++ b/packages/mcp-server/src/mcp-server.test.ts
@@ -70,11 +70,26 @@ describe("McpServer (MCP SDK HTTP Transport)", () => {
 
     await callTool(testKey, "create_note", { id: "Beta", body: "Searchable Body", tags: ["tagB"] });
     await callTool(testKey, "create_note", { id: "Gamma", body: "Mixed Search Text", tags: ["tagA", "tagB"] });
+    await callTool(testKey, "create_note", {
+      id: "Delta",
+      body: "Has custom frontmatter",
+      tags: ["tagC"],
+      frontmatter: { summary: "delta note", rating: 5 },
+    });
 
     const listAll = await callTool(testKey, "list_notes", {});
     const listAllData = extractJsonContent(listAll.body.result);
     expect(Array.isArray(listAllData.notes)).toBe(true);
-    expect(listAllData.notes.find((n: any) => n.id === "alpha.md")).toBeTruthy();
+    const alpha = listAllData.notes.find((n: any) => n.id === "alpha.md");
+    expect(alpha).toBeTruthy();
+    expect(typeof alpha.updatedAt).toBe("number");
+    expect(Array.isArray(alpha.tags)).toBe(true);
+    expect(alpha.tags).toContain("tagA");
+    expect(alpha.frontmatterSummary).toBeUndefined();
+
+    const delta = listAllData.notes.find((n: any) => n.id === "delta.md");
+    expect(delta.tags).toEqual(["tagC"]);
+    expect(delta.frontmatterSummary).toEqual({ summary: "delta note", rating: 5 });
 
     const tagA = await callTool(testKey, "list_notes", { tag: "tagA" });
     const tagAData = extractJsonContent(tagA.body.result);

--- a/packages/mcp-server/src/mcp-server.ts
+++ b/packages/mcp-server/src/mcp-server.ts
@@ -20,6 +20,32 @@ const log = {
   error: (m: string) => console.error(`❌ ${colors.red(m)}`),
 };
 
+const summarizeFrontmatter = (
+  frontmatter: Record<string, unknown>,
+): Record<string, unknown> | undefined => {
+  const summary: Record<string, unknown> = {};
+  for (const [key, value] of Object.entries(frontmatter)) {
+    if (key === "title" || key === "tags") continue;
+    if (value == null) continue;
+    if (
+      typeof value === "string" ||
+      typeof value === "number" ||
+      typeof value === "boolean"
+    ) {
+      summary[key] = value;
+      continue;
+    }
+    if (Array.isArray(value)) {
+      const filtered = value.filter(
+        (v): v is string | number =>
+          typeof v === "string" || typeof v === "number",
+      );
+      if (filtered.length > 0) summary[key] = filtered.slice(0, 10);
+    }
+  }
+  return Object.keys(summary).length > 0 ? summary : undefined;
+};
+
 // Minimal MCP HTTP server exposing /health and /mcp (JSON-RPC + SSE)
 export class McpServer {
   private httpServer: Server | null = null;
@@ -95,7 +121,17 @@ export class McpServer {
         const svc = this.requireService();
         try {
           const notes = await svc.list({ tag: args.tag, search: args.search } as any);
-          const slim = notes.map((n) => ({ id: n.id, title: n.title, version: n.version }));
+          const slim = notes.map((n) => {
+            const frontmatterSummary = summarizeFrontmatter(n.frontmatter);
+            return {
+              id: n.id,
+              title: n.title,
+              version: n.version,
+              updatedAt: n.updatedAt,
+              tags: n.tags,
+              ...(frontmatterSummary ? { frontmatterSummary } : {}),
+            };
+          });
           return { content: [{ type: "text", text: JSON.stringify({ notes: slim }) }] };
         } catch (e) {
           const mapped = mapError(e);


### PR DESCRIPTION
## Summary
- enrich the MCP `list_notes` tool response with updated timestamps, tags, and optional frontmatter summaries
- expand list_notes integration test coverage for the new metadata fields
- document the richer list payload so clients can rely on the expanded schema

## Testing
- bun test packages/mcp-server/src/mcp-server.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68ec25b768688320837bdba1295e98cd