### PR TITLE
Add task management module and UI

### DIFF
--- a/packages/orchard/src/components/TaskModal.svelte
+++ b/packages/orchard/src/components/TaskModal.svelte
@@ -1,0 +1,147 @@
+<script lang="ts">
+import { serializeTaskFrontmatter, type TaskFrontmatter } from "@orchard/core"
+import ModalContent from "@/components/primitives/ModalContent.svelte"
+import DropdownSettingItem, {
+  type DropdownItem,
+} from "@/components/primitives/DropdownSettingItem.svelte"
+import SettingItem from "@/components/primitives/SettingItem.svelte"
+import TextSettingItem from "@/components/primitives/TextSettingItem.svelte"
+import type { TaskSchema } from "@/services/task"
+
+export type TaskModalSubmitDetail = {
+  title: string
+  status: string
+  project: string | null
+  due: string | null
+  priority: string | null
+  frontmatter: TaskFrontmatter
+  body: string
+}
+
+type TaskModalProps = {
+  schema: TaskSchema
+  onSubmit: (detail: TaskModalSubmitDetail) => void
+}
+
+const { schema, onSubmit }: TaskModalProps = $props()
+
+const initialStatus = schema.statuses[0] ?? "todo"
+const statusItems: DropdownItem[] =
+  schema.statuses.length > 0
+    ? schema.statuses.map((status) => ({ label: status, value: status }))
+    : [{ label: initialStatus, value: initialStatus }]
+
+const initialPriority = schema.priorities[0] ?? ""
+const priorityItems: DropdownItem[] =
+  schema.priorities.length > 0
+    ? schema.priorities.map((priority) => ({ label: priority, value: priority }))
+    : initialPriority
+      ? [{ label: initialPriority, value: initialPriority }]
+      : []
+
+let title = $state("")
+let status = $state(initialStatus)
+let project = $state("")
+let due = $state("")
+let priority = $state(initialPriority)
+let notes = $state("")
+
+const handleSubmit = () => {
+  const trimmedTitle = title.trim()
+  if (!trimmedTitle) {
+    return
+  }
+
+  const trimmedProject = project.trim()
+  const trimmedDue = due.trim()
+  const trimmedPriority = priority.trim()
+  const trimmedNotes = notes.replace(/\s+$/u, "")
+
+  const serialized = serializeTaskFrontmatter({
+    status,
+    project: trimmedProject || null,
+    due: trimmedDue || null,
+    priority: trimmedPriority || null,
+    mcpSyncState: null,
+  })
+
+  const frontmatter = (serialized.frontmatter ?? {}) as TaskFrontmatter
+
+  onSubmit({
+    title: trimmedTitle,
+    status,
+    project: trimmedProject || null,
+    due: trimmedDue || null,
+    priority: trimmedPriority || null,
+    frontmatter,
+    body: trimmedNotes,
+  })
+}
+</script>
+
+<ModalContent onSubmit={handleSubmit}>
+  <TextSettingItem
+    name="Title"
+    placeholder="What needs to get done?"
+    bind:value={title}
+    fullWidth
+  />
+
+  <DropdownSettingItem
+    name="Status"
+    value={status}
+    items={statusItems}
+    isPromise={false}
+    onChange={(value) => {
+      status = value
+    }}
+  />
+
+  <TextSettingItem
+    name="Project"
+    placeholder="Optional project label"
+    bind:value={project}
+    fullWidth
+  />
+
+  <SettingItem name="Due Date">
+    {#snippet controlItem()}
+      <input
+        type="date"
+        bind:value={due}
+        style:width="100%"
+      />
+    {/snippet}
+  </SettingItem>
+
+  {#if priorityItems.length > 0}
+    <DropdownSettingItem
+      name="Priority"
+      value={priority}
+      items={priorityItems}
+      isPromise={false}
+      onChange={(value) => {
+        priority = value
+      }}
+    />
+  {/if}
+
+  <SettingItem name="Notes">
+    {#snippet controlItem()}
+      <textarea
+        bind:value={notes}
+        rows={4}
+        class="task-notes"
+        placeholder="Add extra context or links"
+      ></textarea>
+    {/snippet}
+  </SettingItem>
+</ModalContent>
+
+<style>
+  .task-notes {
+    width: 100%;
+    resize: vertical;
+    min-height: 6rem;
+  }
+</style>

--- a/packages/orchard/src/components/TaskQuickActions.svelte
+++ b/packages/orchard/src/components/TaskQuickActions.svelte
@@ -1,0 +1,191 @@
+<script lang="ts">
+import {
+  serializeTaskFrontmatter,
+  type NoteId,
+  type NoteVersion,
+  type TaskFrontmatter,
+  type TaskNote,
+} from "@orchard/core"
+import ModalContent from "@/components/primitives/ModalContent.svelte"
+import DropdownSettingItem, {
+  type DropdownItem,
+} from "@/components/primitives/DropdownSettingItem.svelte"
+import SettingItem from "@/components/primitives/SettingItem.svelte"
+import TextSettingItem from "@/components/primitives/TextSettingItem.svelte"
+import type { TaskSchema } from "@/services/task"
+
+export type TaskQuickActionDetail = {
+  noteId: NoteId
+  version: NoteVersion
+  status: string
+  project: string | null
+  due: string | null
+  priority: string | null
+  frontmatter: TaskFrontmatter
+  body: string
+}
+
+type TaskQuickActionsProps = {
+  task: TaskNote
+  schema: TaskSchema
+  defaultStatus?: string | null
+  onSubmit: (detail: TaskQuickActionDetail) => void
+}
+
+const { task, schema, defaultStatus, onSubmit }: TaskQuickActionsProps = $props()
+
+const fallbackStatus =
+  schema.statuses[0] ?? task.frontmatter.status ?? "todo"
+const statusItems: DropdownItem[] =
+  schema.statuses.length > 0
+    ? schema.statuses.map((status) => ({ label: status, value: status }))
+    : [{ label: fallbackStatus, value: fallbackStatus }]
+
+const fallbackPriority =
+  schema.priorities[0] ?? task.frontmatter.priority ?? ""
+const priorityItems: DropdownItem[] =
+  schema.priorities.length > 0
+    ? schema.priorities.map((priority) => ({ label: priority, value: priority }))
+    : fallbackPriority
+      ? [{ label: fallbackPriority, value: fallbackPriority }]
+      : []
+
+let status = $state(defaultStatus ?? fallbackStatus)
+let project = $state(task.frontmatter.project ?? "")
+let due = $state(task.frontmatter.due ?? "")
+let priority = $state(
+  task.frontmatter.priority ?? (priorityItems[0]?.value ?? ""),
+)
+let notes = $state((task.body ?? "").replace(/\s+$/u, ""))
+
+$effect(() => {
+  if (defaultStatus && defaultStatus !== status) {
+    status = defaultStatus
+  }
+})
+
+const quickSetStatus = (value: string) => {
+  status = value
+}
+
+const handleSubmit = () => {
+  const trimmedProject = project.trim()
+  const trimmedDue = due.trim()
+  const trimmedPriority = priority.trim()
+  const trimmedNotes = notes.replace(/\s+$/u, "")
+
+  const serialized = serializeTaskFrontmatter({
+    status,
+    project: trimmedProject || null,
+    due: trimmedDue || null,
+    priority: trimmedPriority || null,
+    mcpSyncState: task.frontmatter.mcpSyncState ?? null,
+  })
+
+  const frontmatter = (serialized.frontmatter ?? {}) as TaskFrontmatter
+
+  onSubmit({
+    noteId: task.id,
+    version: task.version,
+    status,
+    project: trimmedProject || null,
+    due: trimmedDue || null,
+    priority: trimmedPriority || null,
+    frontmatter,
+    body: trimmedNotes,
+  })
+}
+</script>
+
+<ModalContent onSubmit={handleSubmit}>
+  <SettingItem name="Quick Status" description="Common status presets">
+    {#snippet controlItem()}
+      <div class="status-grid">
+        {#each statusItems.slice(0, 4) as item}
+          <button
+            type="button"
+            class:active={item.value === status}
+            class="status-chip"
+            onclick={() => quickSetStatus(item.value)}
+          >
+            {item.label}
+          </button>
+        {/each}
+      </div>
+    {/snippet}
+  </SettingItem>
+
+  <DropdownSettingItem
+    name="Status"
+    value={status}
+    items={statusItems}
+    isPromise={false}
+    onChange={(value) => {
+      status = value
+    }}
+  />
+
+  <TextSettingItem
+    name="Project"
+    bind:value={project}
+    placeholder="Optional project label"
+    fullWidth
+  />
+
+  <SettingItem name="Due Date">
+    {#snippet controlItem()}
+      <input type="date" bind:value={due} style:width="100%" />
+    {/snippet}
+  </SettingItem>
+
+  {#if priorityItems.length > 0}
+    <DropdownSettingItem
+      name="Priority"
+      value={priority}
+      items={priorityItems}
+      isPromise={false}
+      onChange={(value) => {
+        priority = value
+      }}
+    />
+  {/if}
+
+  <SettingItem name="Notes">
+    {#snippet controlItem()}
+      <textarea
+        bind:value={notes}
+        rows={4}
+        class="task-notes"
+        placeholder="Add context or post-mortems"
+      ></textarea>
+    {/snippet}
+  </SettingItem>
+</ModalContent>
+
+<style>
+  .status-grid {
+    display: flex;
+    gap: 0.5rem;
+    flex-wrap: wrap;
+  }
+
+  .status-chip {
+    border: 1px solid var(--interactive-accent);
+    background-color: transparent;
+    border-radius: 9999px;
+    padding: 0.25rem 0.75rem;
+    cursor: pointer;
+    color: var(--text-normal);
+  }
+
+  .status-chip.active {
+    background-color: var(--interactive-accent);
+    color: var(--text-on-accent);
+  }
+
+  .task-notes {
+    width: 100%;
+    resize: vertical;
+    min-height: 6rem;
+  }
+</style>

--- a/packages/orchard/src/modules/task.module.ts
+++ b/packages/orchard/src/modules/task.module.ts
@@ -1,0 +1,186 @@
+import { TFile } from "obsidian"
+import type { App, Command } from "obsidian"
+import { mount, unmount } from "svelte"
+import TaskModal, {
+  type TaskModalSubmitDetail,
+} from "@/components/TaskModal.svelte"
+import TaskQuickActions, {
+  type TaskQuickActionDetail,
+} from "@/components/TaskQuickActions.svelte"
+import BetterModal from "@/obsidian-extended/better-modal"
+import { notifyErr, notifySuccess } from "@/notify"
+import type { TaskService } from "@/services/task"
+import type { OrchardServices } from "@/services/utils"
+import type { OrchardSettings } from "@/settings/types"
+import type { NoteId, TaskNote } from "@orchard/core"
+
+class TaskModule {
+  readonly app: App
+  readonly tasks: TaskService
+
+  constructor(app: App, _settings: OrchardSettings, services: OrchardServices) {
+    this.app = app
+    this.tasks = services.tasks
+  }
+
+  async registerCommands(): Promise<Command[]> {
+    const commands: Command[] = []
+
+    commands.push({
+      id: "orchard-task-create",
+      name: "Create Task",
+      callback: () => {
+        void this.openCreateTaskModal()
+      },
+    })
+
+    commands.push({
+      id: "orchard-task-mark-done",
+      name: "Mark Task Done",
+      callback: () => {
+        void this.markTaskDone()
+      },
+    })
+
+    commands.push({
+      id: "orchard-task-open-base",
+      name: "Open Task Base",
+      callback: () => {
+        void this.openTaskBase()
+      },
+    })
+
+    return commands
+  }
+
+  private async openCreateTaskModal(): Promise<void> {
+    const modal = new BetterModal(this.app, "Create Orchard Task")
+
+    const component = mount(TaskModal, {
+      target: modal.contentEl,
+      props: {
+        schema: this.tasks.schema,
+        onSubmit: async (detail: TaskModalSubmitDetail) => {
+          modal.disableClose()
+          try {
+            const task = await this.tasks.createTask(this.app.vault, {
+              title: detail.title,
+              frontmatter: detail.frontmatter,
+              body: detail.body,
+            })
+            await this.openTaskNote(task)
+            notifySuccess("Task created")
+            modal.enableClose(true)
+            modal.close()
+          } catch (err) {
+            notifyErr("Failed to create task", err)
+            modal.enableClose(true)
+          }
+        },
+      },
+    })
+
+    modal.registerOnClose(async () => {
+      await unmount(component)
+    })
+
+    modal.open()
+  }
+
+  private async markTaskDone(): Promise<void> {
+    const task = await this.getActiveTask()
+    if (!task) {
+      notifyErr("Open a task note before running this command")
+      return
+    }
+
+    await this.openQuickActions(
+      task,
+      this.resolveDoneStatus(task.frontmatter.status),
+    )
+  }
+
+  private async openQuickActions(
+    task: TaskNote,
+    doneStatus: string,
+  ): Promise<void> {
+    const modal = new BetterModal(this.app, "Update Task")
+
+    const component = mount(TaskQuickActions, {
+      target: modal.contentEl,
+      props: {
+        task,
+        schema: this.tasks.schema,
+        defaultStatus: doneStatus,
+        onSubmit: async (detail: TaskQuickActionDetail) => {
+          modal.disableClose()
+          try {
+            const updated = await this.tasks.updateTask(
+              this.app.vault,
+              detail.noteId,
+              detail.version,
+              {
+                frontmatter: detail.frontmatter,
+                body: detail.body,
+              },
+            )
+            await this.openTaskNote(updated)
+            notifySuccess("Task updated")
+            modal.enableClose(true)
+            modal.close()
+          } catch (err) {
+            notifyErr("Failed to update task", err)
+            modal.enableClose(true)
+          }
+        },
+      },
+    })
+
+    modal.registerOnClose(async () => {
+      await unmount(component)
+    })
+
+    modal.open()
+  }
+
+  private resolveDoneStatus(current: string): string {
+    const statuses = this.tasks.schema.statuses
+    const done = statuses.find((status) => status.toLowerCase() === "done")
+    if (done) return done
+    return statuses[statuses.length - 1] ?? current
+  }
+
+  private async openTaskBase(): Promise<void> {
+    try {
+      await this.tasks.refreshBaseDefinition(this.app.vault)
+      const source = this.app.workspace.getActiveFile()?.path ?? ""
+      await Promise.resolve(
+        this.app.workspace.openLinkText(
+          this.tasks.schema.baseFile,
+          source,
+          false,
+        ),
+      )
+    } catch (err) {
+      notifyErr("Failed to open Orchard task base", err)
+    }
+  }
+
+  private async getActiveTask(): Promise<TaskNote | null> {
+    const file = this.app.workspace.getActiveFile()
+    if (!file) return null
+    return this.tasks.loadTask(file.path as NoteId)
+  }
+
+  private async openTaskNote(task: TaskNote): Promise<void> {
+    const file = this.app.vault.getAbstractFileByPath(task.id)
+    if (file instanceof TFile) {
+      const leaf = this.app.workspace.getLeaf(true)
+      await leaf.openFile(file)
+      return
+    }
+    await Promise.resolve(this.app.workspace.openLinkText(task.id, "", false))
+  }
+}
+
+export default TaskModule

--- a/packages/orchard/src/plugin.ts
+++ b/packages/orchard/src/plugin.ts
@@ -14,6 +14,7 @@ import "./styles.css"
 import "./components/svelte.css"
 import { migrateTaskNotes } from "@/modules/task-migration"
 import VideoModule from "@/modules/video.module"
+import TaskModule from "@/modules/task.module"
 import type { TaskService } from "@/services/task"
 import type { OrchardServices } from "@/services/utils"
 import { wireUpServices } from "@/services/utils"
@@ -31,6 +32,7 @@ class Orchard extends Plugin {
 
   videoModule!: VideoModule
   transcriptionModule!: TranscriptionModule
+  taskModule!: TaskModule
 
   noteService!: NoteService
   taskService!: TaskService
@@ -64,6 +66,7 @@ class Orchard extends Plugin {
       this.settings,
       this.services,
     )
+    this.taskModule = new TaskModule(this.app, this.settings, this.services)
 
     await migrateTaskNotes(this.app, this.taskNotes, this.inlineTasks)
 
@@ -126,6 +129,9 @@ class Orchard extends Plugin {
     const transcriptionCommands =
       await this.transcriptionModule.registerCommands()
     commands.push(...transcriptionCommands)
+
+    const taskCommands = await this.taskModule.registerCommands()
+    commands.push(...taskCommands)
 
     // this.addCommand({
     //   id: "orchard-picker",

--- a/packages/orchard/src/services/task/index.ts
+++ b/packages/orchard/src/services/task/index.ts
@@ -1,3 +1,4 @@
 export type { TaskSchema } from "./schema"
 export { createTaskSchema } from "./schema"
 export { TaskService } from "./service"
+export type { TaskCreateInput, TaskUpdateInput } from "./service"

--- a/packages/orchard/src/services/task/service.ts
+++ b/packages/orchard/src/services/task/service.ts
@@ -1,10 +1,38 @@
 import {
   InlineTaskService,
+  type Note,
+  type NoteId,
   type NoteService,
+  type NoteVersion,
+  serializeTaskFrontmatter,
   TaskNoteService,
+  toTaskNote,
+  type TaskFrontmatter,
+  type TaskNote,
 } from "@orchard/core"
+import type { Vault } from "obsidian"
+
+import {
+  ensureDirectory,
+  ensureTaskBaseDefinition,
+  generateTaskNoteId,
+} from "@/utils/task-files"
 
 import type { TaskSchema } from "./schema"
+
+export interface TaskCreateInput {
+  title: string
+  frontmatter: TaskFrontmatter
+  body?: string
+  tags?: string[]
+}
+
+export interface TaskUpdateInput {
+  frontmatter: TaskFrontmatter
+  body?: string
+  title?: string
+  tags?: string[]
+}
 
 export class TaskService {
   readonly noteService: NoteService
@@ -18,4 +46,101 @@ export class TaskService {
     this.inlineTasks = new InlineTaskService(noteService)
     this.schema = schema
   }
+
+  async refreshBaseDefinition(vault: Vault): Promise<void> {
+    await ensureTaskBaseDefinition(vault, this.schema.baseFile)
+  }
+
+  async createTask(
+    vault: Vault,
+    input: TaskCreateInput,
+    date = new Date(),
+  ): Promise<TaskNote> {
+    const id = generateTaskNoteId(input.title, date, this.schema.folder)
+    await ensureDirectory(vault, toDirname(id))
+
+    const frontmatter = mergeFrontmatter(input.frontmatter)
+    const note = await this.noteService.create({
+      id,
+      title: input.title,
+      tags: input.tags,
+      frontmatter,
+      body: formatBody(input.body),
+    })
+
+    await this.refreshBaseDefinition(vault)
+    return toTaskNote(note)
+  }
+
+  async updateTask(
+    vault: Vault,
+    id: NoteId,
+    expectedVersion: NoteVersion,
+    input: TaskUpdateInput,
+  ): Promise<TaskNote> {
+    const current = await this.noteService.read(id)
+    if (!current) {
+      throw new Error(`Task note not found: ${id}`)
+    }
+
+    const nextFrontmatter = mergeFrontmatter(input.frontmatter, current)
+    const body =
+      input.body !== undefined ? formatBody(input.body) : (current.body ?? "")
+
+    const updated = await this.noteService.update(
+      id,
+      {
+        frontmatter: nextFrontmatter,
+        body,
+        title: input.title,
+        tags: input.tags,
+      },
+      expectedVersion,
+    )
+
+    await this.refreshBaseDefinition(vault)
+    return toTaskNote(updated)
+  }
+
+  async loadTask(id: NoteId): Promise<TaskNote | null> {
+    return this.taskNotes.read(id)
+  }
+}
+
+function formatBody(body: string | undefined): string {
+  if (!body) return ""
+  const trimmed = body.replace(/\s+$/u, "")
+  return trimmed ? `${trimmed}\n` : ""
+}
+
+function toDirname(id: NoteId): string {
+  const segments = id.split("/")
+  if (segments.length <= 1) return ""
+  return segments.slice(0, -1).join("/")
+}
+
+function mergeFrontmatter(
+  incoming: TaskFrontmatter,
+  current?: Note,
+): TaskFrontmatter {
+  const currentFrontmatter =
+    current?.frontmatter && typeof current.frontmatter === "object"
+      ? current.frontmatter
+      : {}
+
+  const normalized = serializeTaskFrontmatter({
+    status: incoming.status,
+    project: incoming.project,
+    due: incoming.due,
+    priority: incoming.priority,
+    mcpSyncState:
+      incoming.mcpSyncState ??
+      (currentFrontmatter.mcpSyncState as string | null | undefined) ??
+      null,
+  }).frontmatter
+
+  return {
+    ...currentFrontmatter,
+    ...normalized,
+  } as TaskFrontmatter
 }

--- a/packages/orchard/src/utils/task-files.ts
+++ b/packages/orchard/src/utils/task-files.ts
@@ -33,30 +33,39 @@ const DEFAULT_TASK_BASE: TaskBaseDefinition = {
   columns: TASK_BASE_COLUMNS,
 }
 
-const TASK_INDEX_HEADER = `---
+const createTaskIndexHeader = (
+  rootDir: string,
+  basePath: string,
+): string => `---
 title: Orchard Tasks
 ---
 # Orchard Tasks
 
-Orchard manages task notes under the \`${TASKS_ROOT_DIR}/\` folder and mirrors them as inline tasks using Dataview metadata.
+Orchard manages task notes under the \`${rootDir}/\` folder and mirrors them as inline tasks using Dataview metadata.
 
-- [[${TASKS_BASE_PATH}|Open the Orchard Tasks Base]]
+- [[${basePath}|Open the Orchard Tasks Base]]
 
 ## Inline Tasks
 `
 
-export function generateTaskNoteId(title: string, date = new Date()): NoteId {
+export function generateTaskNoteId(
+  title: string,
+  date = new Date(),
+  rootDir: string = TASKS_ROOT_DIR,
+): NoteId {
   const year = date.getUTCFullYear()
   const baseSlug = slugifyTaskSegment(title)
   const slug = baseSlug || "task"
   const suffix = timestampSuffix(date)
   const fileName = `${slug}-${suffix}`.toLowerCase()
-  return `${TASKS_ROOT_DIR}/${year}/${fileName}.md` as NoteId
+  const normalizedRoot = normalizeRootDir(rootDir)
+  return `${normalizedRoot}/${year}/${fileName}.md`.toLowerCase() as NoteId
 }
 
 export function expectedTaskFilePath(
   note: Pick<TaskNote, "id" | "title" | "updatedAt">,
   now = new Date(),
+  rootDir: string = TASKS_ROOT_DIR,
 ): NoteId {
   const year = resolveYear(note.updatedAt, now)
   const baseName = extractBasename(note.id) ?? note.title ?? "task"
@@ -64,15 +73,17 @@ export function expectedTaskFilePath(
     slugifyTaskSegment(baseName) || slugifyTaskSegment(note.title) || "task"
   const suffix = hashSuffix(note.id)
   const slug = suffix ? `${baseSlug}-${suffix}` : baseSlug
-  return `${TASKS_ROOT_DIR}/${year}/${slug}.md`.toLowerCase() as NoteId
+  const normalizedRoot = normalizeRootDir(rootDir)
+  return `${normalizedRoot}/${year}/${slug}.md`.toLowerCase() as NoteId
 }
 
 export async function ensureTaskBaseDefinition(
   vault: Vault,
+  basePath: string = TASKS_BASE_PATH,
 ): Promise<TaskBaseDefinition> {
-  await ensureDirectory(vault, getDirname(TASKS_BASE_PATH))
+  await ensureDirectory(vault, getDirname(basePath))
   const adapter = vault.adapter
-  const path = normalizeVaultPath(TASKS_BASE_PATH)
+  const path = normalizeVaultPath(basePath)
   let existing: TaskBaseDefinition | undefined
   if (await adapter.exists(path)) {
     try {
@@ -91,19 +102,26 @@ export async function ensureTaskBaseDefinition(
   return desired
 }
 
-export async function ensureTaskIndexNote(vault: Vault): Promise<void> {
-  const path = normalizeVaultPath(TASKS_INDEX_NOTE)
+export async function ensureTaskIndexNote(
+  vault: Vault,
+  indexPath: string = TASKS_INDEX_NOTE,
+  basePath: string = TASKS_BASE_PATH,
+  rootDir: string = TASKS_ROOT_DIR,
+): Promise<void> {
+  const path = normalizeVaultPath(indexPath)
   await ensureDirectory(vault, getDirname(path))
   const file = vault.getAbstractFileByPath(path)
   if (isVaultFile(file)) {
     const existing = await vault.read(file)
-    if (existing.startsWith(TASK_INDEX_HEADER)) return
+    const header = createTaskIndexHeader(rootDir, basePath)
+    if (existing.startsWith(header)) return
     const preserved = extractInlineTasksSection(existing)
-    const nextContent = `${TASK_INDEX_HEADER}${preserved}`
+    const nextContent = `${header}${preserved}`
     await vault.modify(file, nextContent)
     return
   }
-  await vault.create(path, `${TASK_INDEX_HEADER}\n`)
+  const header = createTaskIndexHeader(rootDir, basePath)
+  await vault.create(path, `${header}\n`)
 }
 
 function extractInlineTasksSection(content: string): string {
@@ -195,6 +213,11 @@ function timestampSuffix(date: Date): string {
   const minute = `${date.getUTCMinutes()}`.padStart(2, "0")
   const second = `${date.getUTCSeconds()}`.padStart(2, "0")
   return `${year}${month}${day}${hour}${minute}${second}`
+}
+
+function normalizeRootDir(rootDir: string): string {
+  if (!rootDir) return TASKS_ROOT_DIR
+  return rootDir.replace(/^\/+|\/+$/g, "")
 }
 
 function resolveYear(updatedAt: number, now: Date): number {


### PR DESCRIPTION
## Summary
- add a TaskModule that wires Orchard task commands and opens the configured base view
- build TaskModal and TaskQuickActions components that serialize metadata with the core task helpers
- extend the task service and utilities so task creation/update refreshes the base definition and honors custom folders

## Testing
- bun run check

------
https://chatgpt.com/codex/tasks/task_e_68ecebe831ac8320af5daf1430ff6eb4