### PR TITLE
feat: add MCP task tooling and events

### DIFF
--- a/packages/mcp-server/src/mcp-server.test.ts
+++ b/packages/mcp-server/src/mcp-server.test.ts
@@ -47,6 +47,34 @@ interface TagsResponse {
   tags: Array<{ name: string; count: number }>
 }
 
+interface TaskLinks {
+  note: { scheme: string; path: string }
+  base?: { scheme: string; path: string }
+  folder?: { path: string }
+}
+
+interface TaskSummary {
+  id: string
+  title: string
+  version: string
+  status: string
+  project: string | null
+  due: string | null
+  priority: string | null
+  mcpSyncState: string | null
+  tags: string[]
+  updatedAt: number
+  links: TaskLinks
+}
+
+interface TaskResponse {
+  task: TaskSummary
+}
+
+interface ListTasksResponse {
+  tasks: TaskSummary[]
+}
+
 interface MetricsResponse {
   notes: number
   uptimeMs: number
@@ -145,6 +173,8 @@ describe("McpServer (MCP SDK HTTP Transport)", () => {
     const tools = toolList?.tools ?? []
     expect(tools.some((t) => t.name === "create_note")).toBe(true)
     expect(tools.some((t) => t.name === "list_tags")).toBe(true)
+    expect(tools.some((t) => t.name === "list_tasks")).toBe(true)
+    expect(tools.some((t) => t.name === "create_task")).toBe(true)
   })
 
   it("creates notes and lists via list_notes filters", async () => {
@@ -213,6 +243,7 @@ describe("McpServer (MCP SDK HTTP Transport)", () => {
       { name: "shared", count: 1 },
       { name: "tagA", count: 2 },
       { name: "tagB", count: 2 },
+      { name: "tagC", count: 1 },
     ])
   })
 
@@ -220,6 +251,72 @@ describe("McpServer (MCP SDK HTTP Transport)", () => {
     const r = await callTool(testKey, "get_note", { id: "alpha.md" })
     const data = extractJsonContent(r.body.result) as NoteResponse
     expect(data.note.body).toBe("Hello")
+  })
+
+  it("creates, lists, and updates tasks", async () => {
+    const created = await callTool(testKey, "create_task", {
+      id: "tasks/TaskOne",
+      title: "Task One",
+      frontmatter: { status: "Todo", project: "Alpha" },
+    })
+    expect(created.status).toBe(200)
+    const createdData = extractJsonContent(created.body.result) as TaskResponse
+    expect(createdData.task.id).toBe("tasks/taskone.md")
+    expect(createdData.task.status).toBe("Todo")
+    expect(createdData.task.project).toBe("Alpha")
+    expect(createdData.task.links.note.path).toBe("tasks/taskone.md")
+    expect(createdData.task.links.base?.path).toContain("orchard-tasks.base.json")
+
+    const listAll = await callTool(testKey, "list_tasks", {})
+    expect(listAll.status).toBe(200)
+    const listAllData = extractJsonContent(listAll.body.result) as ListTasksResponse
+    const entry = listAllData.tasks.find((t) => t.id === "tasks/taskone.md")
+    expect(entry?.status).toBe("Todo")
+    expect(entry?.links.folder?.path).toBe("tasks")
+
+    const update = await callTool(testKey, "update_task", {
+      id: createdData.task.id,
+      version: createdData.task.version,
+      title: "Task One",
+      frontmatter: {
+        status: "Doing",
+        project: "Alpha",
+        priority: "High",
+        due: "2025-01-31",
+        mcpSyncState: "pending",
+      },
+    })
+    expect(update.status).toBe(200)
+    const updatedData = extractJsonContent(update.body.result) as TaskResponse
+    expect(updatedData.task.status).toBe("Doing")
+    expect(updatedData.task.priority).toBe("High")
+    expect(updatedData.task.due).toBe("2025-01-31")
+
+    const transitioned = await callTool(testKey, "transition_task_status", {
+      id: updatedData.task.id,
+      version: updatedData.task.version,
+      status: "Done",
+      project: null,
+      mcpSyncState: "synced",
+    })
+    expect(transitioned.status).toBe(200)
+    const transitionedData = extractJsonContent(transitioned.body.result) as TaskResponse
+    expect(transitionedData.task.status).toBe("Done")
+    expect(transitionedData.task.project).toBeNull()
+    expect(transitionedData.task.mcpSyncState).toBe("synced")
+
+    const filtered = await callTool(testKey, "list_tasks", { status: "done" })
+    expect(filtered.status).toBe(200)
+    const filteredData = extractJsonContent(filtered.body.result) as ListTasksResponse
+    expect(filteredData.tasks.some((t) => t.id === transitionedData.task.id)).toBe(true)
+
+    const rejectOutside = await callTool(testKey, "create_task", {
+      id: "notes/Outside",
+      title: "Outside",
+      frontmatter: { status: "Todo" },
+    })
+    expect(rejectOutside.status).toBe(200)
+    expect(extractErrorCode(rejectOutside.body.result)).toBe("TaskOutsideFolder")
   })
 
   it("normalizes id case + extension on create", async () => {

--- a/packages/mcp-server/src/mcp-server.ts
+++ b/packages/mcp-server/src/mcp-server.ts
@@ -3,12 +3,21 @@ import { createServer, type IncomingHttpHeaders, type Server } from "node:http"
 import { McpServer as SdkMcpServer } from "@modelcontextprotocol/sdk/server/mcp.js"
 import { StreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/streamableHttp.js"
 import { ErrorCode, McpError } from "@modelcontextprotocol/sdk/types.js"
+import {
+  TaskNoteService,
+  normalizeTaskFrontmatter,
+  toTaskNote,
+  validateTaskFrontmatter,
+} from "@orchard/core"
 import type {
   EventBus,
+  Note,
   NoteFilters,
   NoteId,
   NoteService,
   NoteVersion,
+  TaskFrontmatter,
+  TaskNote,
   UpdateNoteMutation,
   VaultAdapter,
 } from "@orchard/core"
@@ -60,11 +69,18 @@ export class McpServer {
   private httpServer: Server | null = null
   private readonly port: number
   private noteService: NoteService | null
+  private taskNotes: TaskNoteService | null = null
   private apiKey: string | null
   private running = false
   private startedAt: number | null = null
   private readonly sdk: SdkMcpServer
   private readonly transport: StreamableHTTPServerTransport
+  private readonly taskFolder: string
+  private readonly taskFolderPrefix: string
+  private readonly taskBaseFile: string | null
+  private events: EventBus | null = null
+  private unsubscribeEvents: (() => void) | null = null
+  private readonly knownTaskIds = new Set<NoteId>()
   setApiKey(key: string) {
     this.apiKey = key
   }
@@ -74,7 +90,13 @@ export class McpServer {
   }
 
   constructor(
-    opts: { port?: number; noteService?: NoteService; apiKey?: string } = {},
+    opts: {
+      port?: number
+      noteService?: NoteService
+      apiKey?: string
+      taskFolder?: string
+      taskBaseFile?: string | null
+    } = {},
   ) {
     const envPort =
       typeof process !== "undefined"
@@ -88,6 +110,18 @@ export class McpServer {
         : undefined
     this.noteService = opts.noteService ?? null
     this.apiKey = opts.apiKey ?? envKey ?? null
+
+    const envTaskFolder =
+      typeof process !== "undefined" ? process.env.MCP_TASK_FOLDER : undefined
+    const envTaskBase =
+      typeof process !== "undefined"
+        ? process.env.MCP_TASK_BASE_FILE
+        : undefined
+    this.taskFolder = normalizeTaskFolder(opts.taskFolder ?? envTaskFolder)
+    this.taskFolderPrefix = this.taskFolder ? `${this.taskFolder}/` : ""
+    const baseFileSource =
+      opts.taskBaseFile !== undefined ? opts.taskBaseFile : envTaskBase
+    this.taskBaseFile = normalizeTaskBaseFile(baseFileSource)
 
     this.sdk = new SdkMcpServer({
       name: "orchard-mcp",
@@ -105,12 +139,20 @@ export class McpServer {
 
   setNoteService(svc: NoteService) {
     this.noteService = svc
+    this.taskNotes = null
+    this.knownTaskIds.clear()
   }
 
   private requireService(): NoteService {
     if (!this.noteService)
       throw new McpError(ErrorCode.InternalError, "NoteServiceUnavailable")
     return this.noteService
+  }
+
+  private requireTaskNotes(): TaskNoteService {
+    const svc = this.requireService()
+    if (!this.taskNotes) this.taskNotes = new TaskNoteService(svc)
+    return this.taskNotes
   }
 
   broadcast(event: string, params: Record<string, unknown>) {
@@ -122,6 +164,124 @@ export class McpServer {
       sdk.notify?.(event, params)
     } catch {
       // ignore
+    }
+  }
+
+  attachEvents(events: EventBus) {
+    this.events = events
+    this.unsubscribeEvents?.()
+    this.unsubscribeEvents = events.subscribe((evt) => {
+      if (!evt || typeof evt !== "object" || !("type" in evt)) return
+      switch (evt.type) {
+        case "note.created":
+          this.handleTaskEvent("task.created", evt.note)
+          break
+        case "note.updated":
+          this.handleTaskEvent("task.updated", evt.note, evt.previousVersion)
+          break
+        case "note.deleted":
+          this.handleTaskDeletion(evt.id, evt.previousVersion)
+          break
+        default:
+          break
+      }
+    })
+  }
+
+  private handleTaskEvent(
+    type: "task.created" | "task.updated",
+    note: Note,
+    previousVersion?: NoteVersion,
+  ) {
+    const id = note.id as NoteId
+    if (!this.isWithinTaskFolder(id)) return
+    try {
+      const task = toTaskNote(note)
+      this.markTaskKnown(task.id)
+      const payload: Record<string, unknown> = {
+        ...this.toTaskPayload(task),
+      }
+      if (previousVersion) payload.previousVersion = previousVersion
+      this.broadcast(type, payload)
+    } catch {
+      // ignore non-task notes
+    }
+  }
+
+  private handleTaskDeletion(id: NoteId, previousVersion: NoteVersion) {
+    this.knownTaskIds.delete(id)
+    if (!this.isWithinTaskFolder(id)) return
+    const payload: Record<string, unknown> = {
+      id,
+      previousVersion,
+      links: this.buildTaskLinks(id),
+    }
+    this.broadcast("task.deleted", payload)
+  }
+
+  private markTaskKnown(id: NoteId) {
+    if (!this.isWithinTaskFolder(id)) return
+    this.knownTaskIds.add(id)
+  }
+
+  private normalizeNoteId(id: string): NoteId {
+    let normalized = id.trim()
+    if (!normalized.endsWith(".md")) normalized = `${normalized}.md`
+    normalized = normalized.replace(/\\+/g, "/")
+    normalized = normalized.toLowerCase()
+    return normalized as NoteId
+  }
+
+  private ensureTaskId(id: string): NoteId {
+    const normalized = this.normalizeNoteId(id)
+    if (normalized.includes("..")) {
+      throw {
+        code: "TaskOutsideFolder",
+        details: { folder: this.taskFolder || "", id: normalized },
+      }
+    }
+    if (!this.isWithinTaskFolder(normalized)) {
+      throw {
+        code: "TaskOutsideFolder",
+        details: { folder: this.taskFolder || "", id: normalized },
+      }
+    }
+    return normalized
+  }
+
+  private isWithinTaskFolder(id: NoteId): boolean {
+    if (!this.taskFolder) return true
+    if (id === this.taskFolder) return true
+    if (this.taskFolderPrefix && id.startsWith(this.taskFolderPrefix)) return true
+    return false
+  }
+
+  private buildTaskLinks(id: NoteId): Record<string, unknown> {
+    const links: Record<string, unknown> = {
+      note: { scheme: "obsidian", path: id },
+    }
+    if (this.taskBaseFile) {
+      links.base = { scheme: "obsidian", path: this.taskBaseFile }
+    }
+    if (this.taskFolder) {
+      links.folder = { path: this.taskFolder }
+    }
+    return links
+  }
+
+  private toTaskPayload(task: TaskNote) {
+    return {
+      id: task.id,
+      title: task.title,
+      version: task.version,
+      tags: task.tags,
+      updatedAt: task.updatedAt,
+      status: task.frontmatter.status,
+      project: task.frontmatter.project,
+      due: task.frontmatter.due,
+      priority: task.frontmatter.priority,
+      mcpSyncState: task.frontmatter.mcpSyncState,
+      links: this.buildTaskLinks(task.id),
     }
   }
 
@@ -140,6 +300,20 @@ export class McpServer {
     const mapError = (
       e: unknown,
     ): { code: string; details?: Record<string, unknown> } => {
+      if (e && typeof e === "object" && "code" in e) {
+        const codeValue = (e as { code?: unknown }).code
+        const details = (e as { details?: unknown }).details
+        return {
+          code:
+            typeof codeValue === "string" && codeValue
+              ? codeValue
+              : "UnknownError",
+          details:
+            details && typeof details === "object"
+              ? (details as Record<string, unknown>)
+              : undefined,
+        }
+      }
       if (e instanceof McpError) return { code: e.message || "McpError" }
       const msg = (e as Error)?.message || "UnknownError"
       if (/already exists/i.test(msg)) return { code: "NoteAlreadyExists" }
@@ -176,6 +350,240 @@ export class McpServer {
           })
           return {
             content: [{ type: "text", text: JSON.stringify({ notes: slim }) }],
+          }
+        } catch (e) {
+          const mapped = mapError(e)
+          return errorContent(mapped.code, mapped.details)
+        }
+      },
+    )
+
+    const taskFrontmatterSchema = z
+      .object({
+        type: z.string().optional(),
+        status: z.string(),
+        project: z.union([z.string(), z.null()]).optional(),
+        due: z.union([z.string(), z.null()]).optional(),
+        priority: z.union([z.string(), z.null()]).optional(),
+        mcpSyncState: z.union([z.string(), z.null()]).optional(),
+      })
+      .passthrough()
+
+    const parseTaskFrontmatter = (value: unknown): TaskFrontmatter => {
+      try {
+        const raw = taskFrontmatterSchema.parse(value) as Record<string, unknown>
+        return validateTaskFrontmatter(raw)
+      } catch (err) {
+        const message = (err as Error)?.message ?? "InvalidTaskFrontmatter"
+        throw {
+          code: "InvalidTaskFrontmatter",
+          details: { message },
+        }
+      }
+    }
+
+    // list_tasks
+    this.sdk.tool(
+      "list_tasks",
+      {
+        tag: z.string().optional(),
+        search: z.string().optional(),
+        status: z.string().optional(),
+        project: z.string().optional(),
+      },
+      async (args: {
+        tag?: string
+        search?: string
+        status?: string
+        project?: string
+      }) => {
+        const svc = this.requireTaskNotes()
+        try {
+          const filters: NoteFilters = {}
+          if (args.tag) filters.tag = args.tag
+          if (args.search) filters.search = args.search
+          const tasks = await svc.list(filters)
+          const filtered = tasks.filter((task) =>
+            this.isWithinTaskFolder(task.id),
+          )
+          const statusFilter = args.status?.trim().toLowerCase()
+          const projectFilter = args.project?.trim().toLowerCase()
+          const subset = filtered.filter((task) => {
+            if (
+              statusFilter &&
+              task.frontmatter.status.toLowerCase() !== statusFilter
+            )
+              return false
+            if (projectFilter !== undefined && projectFilter !== "") {
+              return (
+                (task.frontmatter.project ?? "").toLowerCase() ===
+                projectFilter
+              )
+            }
+            if (projectFilter === "") {
+              return task.frontmatter.project == null
+            }
+            return true
+          })
+          const payload = subset.map((task) => this.toTaskPayload(task))
+          return {
+            content: [
+              { type: "text", text: JSON.stringify({ tasks: payload }) },
+            ],
+          }
+        } catch (e) {
+          const mapped = mapError(e)
+          return errorContent(mapped.code, mapped.details)
+        }
+      },
+    )
+
+    // create_task
+    this.sdk.tool(
+      "create_task",
+      {
+        id: z.string(),
+        title: z.string(),
+        tags: z.array(z.string()).optional(),
+        frontmatter: taskFrontmatterSchema,
+      },
+      async (args: {
+        id: string
+        title: string
+        tags?: string[]
+        frontmatter: Record<string, unknown>
+      }) => {
+        const svc = this.requireTaskNotes()
+        try {
+          const id = this.ensureTaskId(args.id)
+          const frontmatter = parseTaskFrontmatter(args.frontmatter)
+          const created = await svc.create({
+            id,
+            title: args.title,
+            tags: args.tags,
+            status: frontmatter.status,
+            project: frontmatter.project,
+            due: frontmatter.due,
+            priority: frontmatter.priority,
+            mcpSyncState: frontmatter.mcpSyncState,
+          })
+          this.markTaskKnown(created.id)
+          return {
+            content: [
+              { type: "text", text: JSON.stringify({ task: this.toTaskPayload(created) }) },
+            ],
+          }
+        } catch (e) {
+          const mapped = mapError(e)
+          return errorContent(mapped.code, mapped.details)
+        }
+      },
+    )
+
+    // update_task
+    this.sdk.tool(
+      "update_task",
+      {
+        id: z.string(),
+        version: z.string(),
+        title: z.string().optional(),
+        tags: z.array(z.string()).optional(),
+        frontmatter: taskFrontmatterSchema,
+      },
+      async (args: {
+        id: string
+        version: string
+        title?: string
+        tags?: string[]
+        frontmatter: Record<string, unknown>
+      }) => {
+        const svc = this.requireTaskNotes()
+        try {
+          const id = this.ensureTaskId(args.id)
+          const frontmatter = parseTaskFrontmatter(args.frontmatter)
+          const updated = await svc.update(
+            id,
+            {
+              title: args.title,
+              tags: args.tags,
+              status: frontmatter.status,
+              project: frontmatter.project,
+              due: frontmatter.due,
+              priority: frontmatter.priority,
+              mcpSyncState: frontmatter.mcpSyncState,
+            },
+            args.version as NoteVersion,
+          )
+          this.markTaskKnown(updated.id)
+          return {
+            content: [
+              { type: "text", text: JSON.stringify({ task: this.toTaskPayload(updated) }) },
+            ],
+          }
+        } catch (e) {
+          const mapped = mapError(e)
+          return errorContent(mapped.code, mapped.details)
+        }
+      },
+    )
+
+    // transition_task_status
+    this.sdk.tool(
+      "transition_task_status",
+      {
+        id: z.string(),
+        version: z.string(),
+        status: z.string(),
+        project: z.union([z.string(), z.null()]).optional(),
+        due: z.union([z.string(), z.null()]).optional(),
+        priority: z.union([z.string(), z.null()]).optional(),
+        mcpSyncState: z.union([z.string(), z.null()]).optional(),
+      },
+      async (args: {
+        id: string
+        version: string
+        status: string
+        project?: string | null
+        due?: string | null
+        priority?: string | null
+        mcpSyncState?: string | null
+      }) => {
+        const svc = this.requireTaskNotes()
+        try {
+          const id = this.ensureTaskId(args.id)
+          const current = await svc.read(id)
+          if (!current)
+            throw new McpError(ErrorCode.InvalidParams, "TaskNotFound")
+          const normalized = normalizeTaskFrontmatter({
+            status: args.status,
+            project:
+              args.project !== undefined ? args.project : current.frontmatter.project,
+            due: args.due !== undefined ? args.due : current.frontmatter.due,
+            priority:
+              args.priority !== undefined
+                ? args.priority
+                : current.frontmatter.priority,
+            mcpSyncState:
+              args.mcpSyncState !== undefined
+                ? args.mcpSyncState
+                : current.frontmatter.mcpSyncState,
+          })
+          const updated = await svc.update(
+            id,
+            {
+              status: normalized.status,
+              project: normalized.project,
+              due: normalized.due,
+              priority: normalized.priority,
+              mcpSyncState: normalized.mcpSyncState,
+            },
+            args.version as NoteVersion,
+          )
+          this.markTaskKnown(updated.id)
+          return {
+            content: [
+              { type: "text", text: JSON.stringify({ task: this.toTaskPayload(updated) }) },
+            ],
           }
         } catch (e) {
           const mapped = mapError(e)
@@ -492,6 +900,8 @@ export class McpServer {
     if (!this.running) return
     this.running = false
     await this.sdk.close()
+    this.unsubscribeEvents?.()
+    this.unsubscribeEvents = null
     await new Promise<void>((resolve) =>
       this.httpServer?.close(() => resolve()),
     )
@@ -524,6 +934,8 @@ export interface CreateMcpServerOptions {
   apiKey?: string
   noteService?: NoteService
   createAdapter?: () => { adapter: VaultAdapter; events?: EventBus }
+  taskFolder?: string
+  taskBaseFile?: string | null
 }
 
 /**
@@ -566,11 +978,28 @@ export async function createMcpServer(opts: CreateMcpServerOptions = {}) {
     port: opts.port,
     apiKey: opts.apiKey,
     noteService,
+    taskFolder: opts.taskFolder,
+    taskBaseFile: opts.taskBaseFile ?? undefined,
   })
+  if (events) server.attachEvents(events)
   return {
     server,
     noteService,
     start: () => server.start(),
     stop: () => server.stop(),
   } as const
+}
+
+function normalizeTaskFolder(input?: string | null): string {
+  if (input == null) return "tasks"
+  const trimmed = input.trim().replace(/^\/+|\/+$/g, "")
+  if (!trimmed) return ""
+  return trimmed.replace(/\\+/g, "/").toLowerCase()
+}
+
+function normalizeTaskBaseFile(input?: string | null): string | null {
+  if (input == null) return ".obsidian/bases/orchard-tasks.base.json"
+  const trimmed = input.trim()
+  if (!trimmed) return null
+  return trimmed.replace(/\\+/g, "/")
 }

--- a/packages/mcp-server/src/plugin.ts
+++ b/packages/mcp-server/src/plugin.ts
@@ -159,6 +159,7 @@ export default class OrchardMcpPlugin extends Plugin {
     const noteService = new NoteService({ adapter, events })
 
     this.mcp = new McpServer({ noteService, apiKey: this.settings.apiKey })
+    this.mcp.attachEvents(events)
     await this.mcp.start()
     console.log(`[MCP] Server started (storage=${this.settings.storage})`)
   }


### PR DESCRIPTION
## Summary
- add task-aware tooling to the MCP server, validating TaskFrontmatter, exposing Obsidian link hints, and rejecting notes outside the task folder
- bridge core note events to broadcast task.* SSE notifications and wire plugin/startup helpers to attach the event bus
- extend MCP tests to cover task lifecycle flows and folder guard errors

## Testing
- bun test packages/mcp-server/src/mcp-server.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68ed1c1e481883209182d19c93f04ac5