### PR TITLE
Align task index note path casing and guard duplicate creation

### DIFF
--- a/packages/orchard/src/utils/task-files.test.ts
+++ b/packages/orchard/src/utils/task-files.test.ts
@@ -37,6 +37,7 @@ class MockVault {
   adapter: MockAdapter
   private files = new Map<string, { data: string; file: MockFile }>()
   private folders = new Set<string>()
+  createdPaths: string[] = []
 
   constructor() {
     this.adapter = new MockAdapter(this)
@@ -49,6 +50,7 @@ class MockVault {
 
   async create(path: string, data: string) {
     const normalized = normalize(path)
+    this.createdPaths.push(normalized)
     const file = createMockFile(normalized)
     this.files.set(normalized, { data, file })
     return file
@@ -177,5 +179,13 @@ describe("task file helpers", () => {
     const headerPrefix = lines.slice(0, headerEnd + 1).join("\n")
     expect(updated.startsWith(headerPrefix)).toBe(true)
     expect(updated).toContain("note:: [[tasks/sample]]")
+  })
+
+  it("skips creating a duplicate task index note when it already exists", async () => {
+    const vault = new MockVault()
+    await vault.create(TASKS_INDEX_NOTE, "Existing content\n")
+    vault.createdPaths = []
+    await ensureTaskIndexNote(vault as unknown as Vault)
+    expect(vault.createdPaths).toHaveLength(0)
   })
 })

--- a/packages/orchard/src/utils/task-files.ts
+++ b/packages/orchard/src/utils/task-files.ts
@@ -2,7 +2,7 @@ import type { NoteId, TaskNote } from "@orchard/core"
 import type { TFile, Vault } from "obsidian"
 
 export const TASKS_ROOT_DIR = "tasks"
-export const TASKS_INDEX_NOTE = "Tasks/README.md"
+export const TASKS_INDEX_NOTE = "tasks/readme.md"
 export const TASKS_BASE_PATH = ".obsidian/bases/orchard-tasks.base.json"
 
 export interface TaskBaseColumn {
@@ -145,19 +145,19 @@ export async function ensureTaskIndexNote(
   basePath: string = TASKS_BASE_PATH,
   rootDir: string = TASKS_ROOT_DIR,
 ): Promise<void> {
-  const path = normalizeVaultPath(indexPath)
+  const path = normalizeVaultPath(indexPath).toLowerCase()
   await ensureDirectory(vault, getDirname(path))
   const file = vault.getAbstractFileByPath(path)
+  const header = createTaskIndexHeader(rootDir, basePath)
   if (isVaultFile(file)) {
     const existing = await vault.read(file)
-    const header = createTaskIndexHeader(rootDir, basePath)
     if (existing.startsWith(header)) return
     const preserved = extractInlineTasksSection(existing)
     const nextContent = `${header}${preserved}`
     await vault.modify(file, nextContent)
     return
   }
-  const header = createTaskIndexHeader(rootDir, basePath)
+  if (await vault.adapter.exists(path)) return
   await vault.create(path, `${header}\n`)
 }
 


### PR DESCRIPTION
## Summary
- align the task index note path casing with the migration helper so lookups and writes stay consistent
- skip creating the index note when the adapter reports an existing file and track mock vault create calls
- cover the regression with a dedicated test that pre-populates `tasks/readme.md`

## Testing
- bun test packages/orchard/src/utils/task-files.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68eec5d7ea10832085d2f10b25b60d6b